### PR TITLE
Add context inputs for exec.Cmd

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Go Lift - Building Strong Go Tools
+Copyright (c) 2019-2023 Go Lift - Building Strong Go Tools
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/encode.go
+++ b/encode.go
@@ -4,7 +4,6 @@
 package ffmpeg
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -298,18 +297,12 @@ func (e *Encoder) SaveVideoContext(ctx context.Context, input, output, title str
 	cmdStr, cmd := e.getVideoHandle(ctx, input, output, title)
 	// log.Println(cmdStr) // DEBUG
 
-	var out bytes.Buffer
-	cmd.Stderr, cmd.Stdout = &out, &out
-
-	if err := cmd.Start(); err != nil {
-		return cmdStr, strings.TrimSpace(out.String()), fmt.Errorf("subcommand failed: %w", err)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return cmdStr, string(out), fmt.Errorf("subcommand failed: %w", err)
 	}
 
-	if err := cmd.Wait(); err != nil {
-		return cmdStr, strings.TrimSpace(out.String()), fmt.Errorf("subcommand failed: %w", err)
-	}
-
-	return cmdStr, strings.TrimSpace(out.String()), nil
+	return cmdStr, string(out), nil
 }
 
 // fixValues makes sure video request values are sane.

--- a/encode.go
+++ b/encode.go
@@ -235,6 +235,7 @@ func (e *Encoder) GetVideo(input, title string) (string, io.ReadCloser, error) {
 
 	if e.config.Time > 0 {
 		var cancel func()
+
 		ctx, cancel = context.WithTimeout(ctx, time.Second*time.Duration(e.config.Time+1))
 		defer cancel()
 	}

--- a/encode.go
+++ b/encode.go
@@ -277,6 +277,7 @@ func (e *Encoder) SaveVideo(input, output, title string) (string, string, error)
 
 	if e.config.Time > 0 {
 		var cancel func()
+
 		ctx, cancel = context.WithTimeout(ctx, time.Second*time.Duration(e.config.Time+1))
 		defer cancel()
 	}

--- a/encode_test.go
+++ b/encode_test.go
@@ -68,7 +68,7 @@ func TestSaveVideo(t *testing.T) {
 	assert.True(strings.HasPrefix(cmd, "echo"), "The command does not - but should - begin with the Encoder value.")
 	assert.True(strings.HasSuffix(cmd, fileTemp),
 		"The command does not - but should - end with a dash to indicate output to stdout.")
-	assert.EqualValues(cmd+"\n", "echo "+out, "Somehow the wrong value was written")
+	assert.EqualValues(cmd, "echo "+strings.TrimSpace(out), "Somehow the wrong value was written")
 
 	// Make sure audio can be turned on.
 	encode = Get(&Config{FFMPEG: "echo", Audio: true})

--- a/encode_test.go
+++ b/encode_test.go
@@ -68,7 +68,7 @@ func TestSaveVideo(t *testing.T) {
 	assert.True(strings.HasPrefix(cmd, "echo"), "The command does not - but should - begin with the Encoder value.")
 	assert.True(strings.HasSuffix(cmd, fileTemp),
 		"The command does not - but should - end with a dash to indicate output to stdout.")
-	assert.EqualValues(cmd, "echo "+out, "Somehow the wrong value was written")
+	assert.EqualValues(cmd+"\n", "echo "+out, "Somehow the wrong value was written")
 
 	// Make sure audio can be turned on.
 	encode = Get(&Config{FFMPEG: "echo", Audio: true})

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,11 @@
 module golift.io/ffmpeg
 
-go 1.15
+go 1.19
 
 require github.com/stretchr/testify v1.8.2
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,3 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -7,16 +6,12 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Adds two new methods with context inputs. Updates the existing methods to add a sensible context timeout when possible. This should help with hanging `ffmpeg` commands. 

- Closes #2.